### PR TITLE
Add initial tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 # Data/creds
 params.yaml
 
-# OS
+# Local
 .DS_Store
-
+.vscode/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ Then run:
 - `pre-commit install`
 
 To run the app locally: `streamlit run app.py`
+
+## Unit tests
+
+Run `pip install -e .` before running tests locally.
+
+After that they should run happily with `pytest`.
+
+On reflection, maybe I'd have been better with integration tests that get real responses from Spotify? Create, manipulate and destroy a temporary playlist?

--- a/app.py
+++ b/app.py
@@ -14,9 +14,9 @@ from shuffle_by_album.streamlit_functions import (
     display_album,
     add_and_print_songs,
 )
-from shuffle_by_album.constants import title
+from shuffle_by_album.constants import title, params_filename
 
-params = get_params("params.yaml")
+params = get_params(params_filename)
 auth = authenticate_spotify(params)
 sp = spotipy.Spotify(auth_manager=auth)
 

--- a/app.py
+++ b/app.py
@@ -2,12 +2,12 @@ import spotipy
 import streamlit as st
 
 from shuffle_by_album.spotify_functions import (
+    NotEnoughAlbums,
     authenticate_spotify,
     get_params,
     playlist_albums,
     pick_albums,
     extract_album_info,
-    valid_count,
 )
 from shuffle_by_album.streamlit_functions import (
     cache_playlists,
@@ -59,7 +59,7 @@ def main():
     st.title(title)
 
     if st.button("Pick albums"):
-        if valid_count(potential_albums, st.session_state.album_count):
+        try:
             st.session_state.albums = pick_albums(
                 potential_albums, st.session_state.album_count
             )
@@ -70,12 +70,9 @@ def main():
             for a in st.session_state.album_info:
                 display_album(a)
 
-        else:
+        except NotEnoughAlbums as e:
             st.session_state.albums = []
-            (
-                f"The selected playlist isn't long enough to pick "
-                f"{st.session_state.album_count} albums"
-            )
+            st.write(str(e))
 
     if st.button("Add to playlist"):
         if st.session_state.albums:

--- a/app.py
+++ b/app.py
@@ -21,16 +21,16 @@ auth = authenticate_spotify(params)
 sp = spotipy.Spotify(auth_manager=auth)
 
 # Initialise session variables
-if "input_playlist_id" not in st.session_state:
-    st.session_state.input_playlist_id = None
-if "output_playlist_id" not in st.session_state:
-    st.session_state.output_playlist_id = None
-if "album_count" not in st.session_state:
-    st.session_state.album_count = 1
-if "albums" not in st.session_state:
-    st.session_state.albums = []
-if "album_info" not in st.session_state:
-    st.session_state.album_info = []
+variables = [
+    "input_playlist_id",
+    "output_playlist_id",
+    "album_count",
+    "albums",
+    "album_info",
+]
+for v in variables:
+    if v not in st.session_state:
+        setattr(st.session_state, v, None)
 
 
 def main():

--- a/shuffle_by_album/constants.py
+++ b/shuffle_by_album/constants.py
@@ -1,1 +1,2 @@
+params_filename = "params.yaml"
 title = "Shuffle by album"

--- a/tester.ipynb
+++ b/tester.ipynb
@@ -26,6 +26,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "sp.current_user_playlists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "input_playlist_id = playlist_id_dict(sp)[\"Album shuffle input\"]"
    ]
   },

--- a/tester.ipynb
+++ b/tester.ipynb
@@ -11,57 +11,12 @@
     "from shuffle_by_album.spotify_functions import (\n",
     "    get_params,\n",
     "    authenticate_spotify,\n",
-    "    playlist_id_dict,\n",
-    "    playlist_albums,\n",
     ")\n",
     "\n",
     "params = get_params(\"params.yaml\")\n",
     "auth = authenticate_spotify(params)\n",
     "sp = spotipy.Spotify(auth_manager=auth)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sp.current_user_playlists()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "input_playlist_id = playlist_id_dict(sp)[\"Album shuffle input\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "albums = playlist_albums(sp, input_playlist_id)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "albums[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tests/mock_params.yaml
+++ b/tests/mock_params.yaml
@@ -1,0 +1,4 @@
+# Mock authentication
+client_id: mock_id1234
+client_secret: mock_secret5678
+redirect_uri: "http://localhost:8080"

--- a/tests/mock_spotipy_client.py
+++ b/tests/mock_spotipy_client.py
@@ -1,82 +1,92 @@
-playlist_data = {
+playlists_response = {
     "href": "https://api.spotify.com/v1/users/mock_user/playlists?offset=0&limit=50",
     "items": [
         {
-            "collaborative": False,
-            "description": "Test playlist",
-            "external_urls": {"spotify": "https://open.spotify.com/playlist/1"},
-            "href": "https://api.spotify.com/v1/playlists/1",
             "id": "test_playlist_1",
-            "images": [
-                {
-                    "height": 640,
-                    "url": "https://i.scdn.co/image/1",
-                    "width": 640,
-                }
-            ],
             "name": "Test playlist 1",
-            "owner": {
-                "display_name": "mock_user",
-                "external_urls": {"spotify": "https://open.spotify.com/user/mock_user"},
-                "href": "https://api.spotify.com/v1/users/mock_user",
-                "id": "mock_user",
-                "type": "user",
-                "uri": "spotify:user:mock_user",
-            },
-            "primary_color": None,
-            "public": False,
-            "snapshot_id": "snapshot_string==",
-            "tracks": {
-                "href": "https://api.spotify.com/v1/playlists/1/tracks",
-                "total": 9,
-            },
-            "type": "playlist",
-            "uri": "spotify:playlist:1",
         },
         {
-            "collaborative": False,
-            "description": "Test playlist 2",
-            "external_urls": {"spotify": "https://open.spotify.com/playlist/2"},
-            "href": "https://api.spotify.com/v1/playlists/2",
             "id": "test_playlist_2",
-            "images": [
-                {
-                    "height": 640,
-                    "url": "https://i.scdn.co/image/2",
-                    "width": 640,
-                }
-            ],
             "name": "Test playlist 2",
-            "owner": {
-                "display_name": "mock_user",
-                "external_urls": {"spotify": "https://open.spotify.com/user/mock_user"},
-                "href": "https://api.spotify.com/v1/users/mock_user",
-                "id": "mock_user",
-                "type": "user",
-                "uri": "spotify:user:mock_user",
-            },
-            "primary_color": None,
-            "public": False,
-            "snapshot_id": "snapshot_string==",
-            "tracks": {
-                "href": "https://api.spotify.com/v1/playlists/2/tracks",
-                "total": 90,
-            },
-            "type": "playlist",
-            "uri": "spotify:playlist:2",
         },
     ],
-    "limit": 50,
-    "next": None,
-    "offset": 0,
-    "previous": None,
     "total": 2,
+}
+playlist_response = {
+    "tracks": {
+        "items": [
+            {
+                "track": {
+                    "album": {
+                        "artists": [
+                            {
+                                "name": "Test artist",
+                            }
+                        ],
+                        "id": "album_id_1",
+                        "images": [
+                            {
+                                "height": 640,
+                                "url": "https://i.scdn.co/image/album_1_big",
+                                "width": 640,
+                            },
+                            {
+                                "height": 300,
+                                "url": "https://i.scdn.co/image/album_1_medium",
+                                "width": 300,
+                            },
+                            {
+                                "height": 64,
+                                "url": "https://i.scdn.co/image/album_1_small",
+                                "width": 64,
+                            },
+                        ],
+                        "name": "Test Album One",
+                    }
+                }
+            },
+            {
+                "track": {
+                    "album": {
+                        "artists": [
+                            {
+                                "name": "Test artist 2",
+                            }
+                        ],
+                        "id": "album_id_2",
+                        "images": [
+                            {
+                                "height": 640,
+                                "url": "https://i.scdn.co/image/album_2_big",
+                                "width": 640,
+                            },
+                            {
+                                "height": 300,
+                                "url": "https://i.scdn.co/image/album_2_medium",
+                                "width": 300,
+                            },
+                            {
+                                "height": 64,
+                                "url": "https://i.scdn.co/image/album_2_small",
+                                "width": 64,
+                            },
+                        ],
+                        "name": "Test Album Two",
+                    }
+                }
+            },
+        ]
+    }
 }
 
 
 class MockSpotipy:
     def __init__(self):
-        self.playlists = playlist_data
+        self.playlists_response = playlists_response
+        self.playlist_response = playlist_response
 
     def current_user_playlists(self):
-        return self.playlists
+        return self.playlists_response
+
+    def playlist(self, playlist_id, fields):
+        return self.playlist_response

--- a/tests/mock_spotipy_client.py
+++ b/tests/mock_spotipy_client.py
@@ -1,0 +1,82 @@
+playlist_data = {
+    "href": "https://api.spotify.com/v1/users/mock_user/playlists?offset=0&limit=50",
+    "items": [
+        {
+            "collaborative": False,
+            "description": "Test playlist",
+            "external_urls": {"spotify": "https://open.spotify.com/playlist/1"},
+            "href": "https://api.spotify.com/v1/playlists/1",
+            "id": "test_playlist_1",
+            "images": [
+                {
+                    "height": 640,
+                    "url": "https://i.scdn.co/image/1",
+                    "width": 640,
+                }
+            ],
+            "name": "Test playlist 1",
+            "owner": {
+                "display_name": "mock_user",
+                "external_urls": {"spotify": "https://open.spotify.com/user/mock_user"},
+                "href": "https://api.spotify.com/v1/users/mock_user",
+                "id": "mock_user",
+                "type": "user",
+                "uri": "spotify:user:mock_user",
+            },
+            "primary_color": None,
+            "public": False,
+            "snapshot_id": "snapshot_string==",
+            "tracks": {
+                "href": "https://api.spotify.com/v1/playlists/1/tracks",
+                "total": 9,
+            },
+            "type": "playlist",
+            "uri": "spotify:playlist:1",
+        },
+        {
+            "collaborative": False,
+            "description": "Test playlist 2",
+            "external_urls": {"spotify": "https://open.spotify.com/playlist/2"},
+            "href": "https://api.spotify.com/v1/playlists/2",
+            "id": "test_playlist_2",
+            "images": [
+                {
+                    "height": 640,
+                    "url": "https://i.scdn.co/image/2",
+                    "width": 640,
+                }
+            ],
+            "name": "Test playlist 2",
+            "owner": {
+                "display_name": "mock_user",
+                "external_urls": {"spotify": "https://open.spotify.com/user/mock_user"},
+                "href": "https://api.spotify.com/v1/users/mock_user",
+                "id": "mock_user",
+                "type": "user",
+                "uri": "spotify:user:mock_user",
+            },
+            "primary_color": None,
+            "public": False,
+            "snapshot_id": "snapshot_string==",
+            "tracks": {
+                "href": "https://api.spotify.com/v1/playlists/2/tracks",
+                "total": 90,
+            },
+            "type": "playlist",
+            "uri": "spotify:playlist:2",
+        },
+    ],
+    "limit": 50,
+    "next": None,
+    "offset": 0,
+    "previous": None,
+    "total": 2,
+}
+
+
+class MockSpotipy:
+    def __init__(self):
+        self.playlists = playlist_data
+
+    def current_user_playlists(self):
+        return self.playlists

--- a/tests/mock_spotipy_client.py
+++ b/tests/mock_spotipy_client.py
@@ -12,34 +12,22 @@ playlists_response = {
     ],
     "total": 2,
 }
+# This playlist contains:
+# 2 tracks from album 1, by artist 1
+# 1 track from album 2, by artist 2
+# 1 track from album 3, by artist 2
 playlist_response = {
     "tracks": {
         "items": [
             {
                 "track": {
                     "album": {
-                        "artists": [
-                            {
-                                "name": "Test artist",
-                            }
-                        ],
+                        "artists": [{"name": "Test artist"}],
                         "id": "album_id_1",
                         "images": [
-                            {
-                                "height": 640,
-                                "url": "https://i.scdn.co/image/album_1_big",
-                                "width": 640,
-                            },
-                            {
-                                "height": 300,
-                                "url": "https://i.scdn.co/image/album_1_medium",
-                                "width": 300,
-                            },
-                            {
-                                "height": 64,
-                                "url": "https://i.scdn.co/image/album_1_small",
-                                "width": 64,
-                            },
+                            {"url": "https://i.scdn.co/image/album_1_big"},
+                            {"url": "https://i.scdn.co/image/album_1_medium"},
+                            {"url": "https://i.scdn.co/image/album_1_small"},
                         ],
                         "name": "Test Album One",
                     }
@@ -48,30 +36,42 @@ playlist_response = {
             {
                 "track": {
                     "album": {
-                        "artists": [
-                            {
-                                "name": "Test artist 2",
-                            }
-                        ],
+                        "artists": [{"name": "Test artist 2"}],
                         "id": "album_id_2",
                         "images": [
-                            {
-                                "height": 640,
-                                "url": "https://i.scdn.co/image/album_2_big",
-                                "width": 640,
-                            },
-                            {
-                                "height": 300,
-                                "url": "https://i.scdn.co/image/album_2_medium",
-                                "width": 300,
-                            },
-                            {
-                                "height": 64,
-                                "url": "https://i.scdn.co/image/album_2_small",
-                                "width": 64,
-                            },
+                            {"url": "https://i.scdn.co/image/album_2_big"},
+                            {"url": "https://i.scdn.co/image/album_2_medium"},
+                            {"url": "https://i.scdn.co/image/album_2_small"},
                         ],
                         "name": "Test Album Two",
+                    }
+                }
+            },
+            {
+                "track": {
+                    "album": {
+                        "artists": [{"name": "Test artist"}],
+                        "id": "album_id_1",
+                        "images": [
+                            {"url": "https://i.scdn.co/image/album_1_big"},
+                            {"url": "https://i.scdn.co/image/album_1_medium"},
+                            {"url": "https://i.scdn.co/image/album_1_small"},
+                        ],
+                        "name": "Test Album One",
+                    }
+                }
+            },
+            {
+                "track": {
+                    "album": {
+                        "artists": [{"name": "Test artist 2"}],
+                        "id": "album_id_3",
+                        "images": [
+                            {"url": "https://i.scdn.co/image/album_3_big"},
+                            {"url": "https://i.scdn.co/image/album_3_medium"},
+                            {"url": "https://i.scdn.co/image/album_3_small"},
+                        ],
+                        "name": "Test Album Three",
                     }
                 }
             },

--- a/tests/mock_spotipy_client.py
+++ b/tests/mock_spotipy_client.py
@@ -90,3 +90,11 @@ class MockSpotipy:
 
     def playlist(self, playlist_id, fields):
         return self.playlist_response
+
+    def album_tracks(self, album_id):
+        tracks = {
+            "album_id_1": [{"id": "song_1"}, {"id": "song_2"}],
+            "album_id_3": [{"id": "song_5"}, {"id": "song_6"}],
+            "album_id_2": [{"id": "song_3"}, {"id": "song_4"}],
+        }
+        return {"items": tracks[album_id]}

--- a/tests/test_spotify_functions.py
+++ b/tests/test_spotify_functions.py
@@ -7,8 +7,7 @@ from shuffle_by_album.spotify_functions import (
     playlist_albums,
     valid_count,
     pick_albums,
-    # extract_album_info,
-    # add_songs,
+    extract_album_info,
 )
 from tests.mock_spotipy_client import MockSpotipy
 
@@ -193,3 +192,21 @@ def test_pick_albums(album_count, seed, expected, album_data):
         # Sort result because function uses sets
         result = pick_albums(album_data, album_count, seed)
         assert sorted(result, key=lambda x: x["id"]) == expected
+
+
+def test_extract_album_info(mock_client, album_data):
+    chosen_albums = album_data[0:2]
+    assert extract_album_info(mock_client, chosen_albums) == [
+        {
+            "name": "Test Album One",
+            "artists": ["Test artist"],
+            "image": "https://i.scdn.co/image/album_1_small",
+            "songs": ["song_1", "song_2"],
+        },
+        {
+            "name": "Test Album Two",
+            "artists": ["Test artist 2"],
+            "image": "https://i.scdn.co/image/album_2_small",
+            "songs": ["song_3", "song_4"],
+        },
+    ]

--- a/tests/test_spotify_functions.py
+++ b/tests/test_spotify_functions.py
@@ -1,5 +1,47 @@
-from shuffle_by_album.spotify_functions import valid_count
+import pytest
+
+from shuffle_by_album.spotify_functions import (
+    get_params,
+    playlist_id_dict,
+    # playlist_albums,
+    valid_count,
+    # pick_albums,
+    # extract_album_info,
+    # add_songs,
+)
+from tests.mock_spotipy_client import MockSpotipy
 
 
-def test_valid_count():
-    assert valid_count([{"id": 1}], 1)
+@pytest.fixture(scope="session")
+def mock_client():
+    return MockSpotipy()
+
+
+def test_get_params():
+    params = get_params("tests/mock_params.yaml")
+    assert params["client_id"] == "mock_id1234"
+    assert params["client_secret"] == "mock_secret5678"
+    assert params["redirect_uri"] == "http://localhost:8080"
+
+
+def test_playlist_id_dict(mock_client):
+    assert playlist_id_dict(mock_client) == {
+        "Test playlist 1": "test_playlist_1",
+        "Test playlist 2": "test_playlist_2",
+    }
+
+
+@pytest.mark.parametrize(
+    "album_ids, album_count, expected",
+    [
+        ([1], 1, True),
+        ([1, 2, 3, 4], 4, True),
+        ([1, 1, 2, 2], 2, True),
+        ([], 1, False),
+        ([1, 2], 3, False),
+        ([1, 1, 2, 2], 3, False),
+    ],
+)
+def test_valid_count(album_ids, album_count, expected):
+    album_data = [{"id": num} for num in album_ids]
+    assert valid_count(album_data, album_count) == expected

--- a/tests/test_spotify_functions.py
+++ b/tests/test_spotify_functions.py
@@ -1,11 +1,12 @@
 import pytest
 
 from shuffle_by_album.spotify_functions import (
+    NotEnoughAlbums,
     get_params,
     playlist_id_dict,
     playlist_albums,
     valid_count,
-    # pick_albums,
+    pick_albums,
     # extract_album_info,
     # add_songs,
 )
@@ -15,6 +16,52 @@ from tests.mock_spotipy_client import MockSpotipy
 @pytest.fixture(scope="session")
 def mock_client():
     return MockSpotipy()
+
+
+@pytest.fixture(scope="session")
+def album_data():
+    return [
+        {
+            "artists": [{"name": "Test artist"}],
+            "id": "album_id_1",
+            "images": [
+                {"url": "https://i.scdn.co/image/album_1_big"},
+                {"url": "https://i.scdn.co/image/album_1_medium"},
+                {"url": "https://i.scdn.co/image/album_1_small"},
+            ],
+            "name": "Test Album One",
+        },
+        {
+            "artists": [{"name": "Test artist 2"}],
+            "id": "album_id_2",
+            "images": [
+                {"url": "https://i.scdn.co/image/album_2_big"},
+                {"url": "https://i.scdn.co/image/album_2_medium"},
+                {"url": "https://i.scdn.co/image/album_2_small"},
+            ],
+            "name": "Test Album Two",
+        },
+        {
+            "artists": [{"name": "Test artist"}],
+            "id": "album_id_1",
+            "images": [
+                {"url": "https://i.scdn.co/image/album_1_big"},
+                {"url": "https://i.scdn.co/image/album_1_medium"},
+                {"url": "https://i.scdn.co/image/album_1_small"},
+            ],
+            "name": "Test Album One",
+        },
+        {
+            "artists": [{"name": "Test artist 2"}],
+            "id": "album_id_3",
+            "images": [
+                {"url": "https://i.scdn.co/image/album_3_big"},
+                {"url": "https://i.scdn.co/image/album_3_medium"},
+                {"url": "https://i.scdn.co/image/album_3_small"},
+            ],
+            "name": "Test Album Three",
+        },
+    ]
 
 
 def test_get_params():
@@ -31,73 +78,118 @@ def test_playlist_id_dict(mock_client):
     }
 
 
-def test_playlist_albums(mock_client):
-    album_1 = {
-        "artists": [
-            {
-                "name": "Test artist",
-            }
-        ],
-        "id": "album_id_1",
-        "images": [
-            {
-                "height": 640,
-                "url": "https://i.scdn.co/image/album_1_big",
-                "width": 640,
-            },
-            {
-                "height": 300,
-                "url": "https://i.scdn.co/image/album_1_medium",
-                "width": 300,
-            },
-            {
-                "height": 64,
-                "url": "https://i.scdn.co/image/album_1_small",
-                "width": 64,
-            },
-        ],
-        "name": "Test Album One",
-    }
-    album_2 = {
-        "artists": [
-            {
-                "name": "Test artist 2",
-            }
-        ],
-        "id": "album_id_2",
-        "images": [
-            {
-                "height": 640,
-                "url": "https://i.scdn.co/image/album_2_big",
-                "width": 640,
-            },
-            {
-                "height": 300,
-                "url": "https://i.scdn.co/image/album_2_medium",
-                "width": 300,
-            },
-            {
-                "height": 64,
-                "url": "https://i.scdn.co/image/album_2_small",
-                "width": 64,
-            },
-        ],
-        "name": "Test Album Two",
-    }
-    assert playlist_albums(mock_client, "not tested") == [album_1, album_2]
+def test_playlist_albums(mock_client, album_data):
+    result = playlist_albums(mock_client, "not tested")
+    assert result == album_data
 
 
 @pytest.mark.parametrize(
-    "album_ids, album_count, expected",
+    "album_ids, album_count, expected, unique_count",
     [
-        ([1], 1, True),
-        ([1, 2, 3, 4], 4, True),
-        ([1, 1, 2, 2], 2, True),
-        ([], 1, False),
-        ([1, 2], 3, False),
-        ([1, 1, 2, 2], 3, False),
+        ([1], 1, True, 1),
+        ([1, 2, 3, 4], 4, True, 4),
+        ([1, 1, 2, 2], 2, True, 2),
+        ([], 1, False, 0),
+        ([1, 2], 3, False, 2),
+        ([1, 1, 2, 2], 3, False, 2),
     ],
 )
-def test_valid_count(album_ids, album_count, expected):
+def test_valid_count(album_ids, album_count, expected, unique_count):
     album_data = [{"id": num} for num in album_ids]
-    assert valid_count(album_data, album_count) == expected
+    if expected:
+        assert valid_count(album_data, album_count) == expected
+    else:
+        expected_error = (
+            f"You asked for {album_count} albums, but "
+            f"this playlist only contains {unique_count}"
+        )
+        with pytest.raises(NotEnoughAlbums, match=expected_error):
+            valid_count(album_data, album_count)
+
+
+@pytest.mark.parametrize(
+    "album_count, seed, expected",
+    [
+        # Get 4 unique albums when there are only 3
+        (4, 100, "ERROR"),
+        # Get 1
+        (
+            1,
+            100,
+            [
+                {
+                    "artists": [{"name": "Test artist 2"}],
+                    "id": "album_id_2",
+                    "images": [
+                        {"url": "https://i.scdn.co/image/album_2_big"},
+                        {"url": "https://i.scdn.co/image/album_2_medium"},
+                        {"url": "https://i.scdn.co/image/album_2_small"},
+                    ],
+                    "name": "Test Album Two",
+                }
+            ],
+        ),
+        # Get 1 with another seed
+        (
+            1,
+            50,
+            [
+                {
+                    "artists": [{"name": "Test artist 2"}],
+                    "id": "album_id_3",
+                    "images": [
+                        {"url": "https://i.scdn.co/image/album_3_big"},
+                        {"url": "https://i.scdn.co/image/album_3_medium"},
+                        {"url": "https://i.scdn.co/image/album_3_small"},
+                    ],
+                    "name": "Test Album Three",
+                }
+            ],
+        ),
+        # Get them all
+        (
+            3,
+            100,
+            [
+                {
+                    "artists": [{"name": "Test artist"}],
+                    "id": "album_id_1",
+                    "images": [
+                        {"url": "https://i.scdn.co/image/album_1_big"},
+                        {"url": "https://i.scdn.co/image/album_1_medium"},
+                        {"url": "https://i.scdn.co/image/album_1_small"},
+                    ],
+                    "name": "Test Album One",
+                },
+                {
+                    "artists": [{"name": "Test artist 2"}],
+                    "id": "album_id_2",
+                    "images": [
+                        {"url": "https://i.scdn.co/image/album_2_big"},
+                        {"url": "https://i.scdn.co/image/album_2_medium"},
+                        {"url": "https://i.scdn.co/image/album_2_small"},
+                    ],
+                    "name": "Test Album Two",
+                },
+                {
+                    "artists": [{"name": "Test artist 2"}],
+                    "id": "album_id_3",
+                    "images": [
+                        {"url": "https://i.scdn.co/image/album_3_big"},
+                        {"url": "https://i.scdn.co/image/album_3_medium"},
+                        {"url": "https://i.scdn.co/image/album_3_small"},
+                    ],
+                    "name": "Test Album Three",
+                },
+            ],
+        ),
+    ],
+)
+def test_pick_albums(album_count, seed, expected, album_data):
+    if expected == "ERROR":
+        with pytest.raises(NotEnoughAlbums):
+            pick_albums(album_data, album_count, seed)
+    else:
+        # Sort result because function uses sets
+        result = pick_albums(album_data, album_count, seed)
+        assert sorted(result, key=lambda x: x["id"]) == expected

--- a/tests/test_spotify_functions.py
+++ b/tests/test_spotify_functions.py
@@ -3,7 +3,7 @@ import pytest
 from shuffle_by_album.spotify_functions import (
     get_params,
     playlist_id_dict,
-    # playlist_albums,
+    playlist_albums,
     valid_count,
     # pick_albums,
     # extract_album_info,
@@ -29,6 +29,62 @@ def test_playlist_id_dict(mock_client):
         "Test playlist 1": "test_playlist_1",
         "Test playlist 2": "test_playlist_2",
     }
+
+
+def test_playlist_albums(mock_client):
+    album_1 = {
+        "artists": [
+            {
+                "name": "Test artist",
+            }
+        ],
+        "id": "album_id_1",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/album_1_big",
+                "width": 640,
+            },
+            {
+                "height": 300,
+                "url": "https://i.scdn.co/image/album_1_medium",
+                "width": 300,
+            },
+            {
+                "height": 64,
+                "url": "https://i.scdn.co/image/album_1_small",
+                "width": 64,
+            },
+        ],
+        "name": "Test Album One",
+    }
+    album_2 = {
+        "artists": [
+            {
+                "name": "Test artist 2",
+            }
+        ],
+        "id": "album_id_2",
+        "images": [
+            {
+                "height": 640,
+                "url": "https://i.scdn.co/image/album_2_big",
+                "width": 640,
+            },
+            {
+                "height": 300,
+                "url": "https://i.scdn.co/image/album_2_medium",
+                "width": 300,
+            },
+            {
+                "height": 64,
+                "url": "https://i.scdn.co/image/album_2_small",
+                "width": 64,
+            },
+        ],
+        "name": "Test Album Two",
+    }
+    assert playlist_albums(mock_client, "not tested") == [album_1, album_2]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Mainly adding rudimentary unit tests for the Spotify side of things. But also: 

- tidied up initialisation of Streamlit session variables 
- better error handling when too many albums requested